### PR TITLE
fix: added explicit encoding

### DIFF
--- a/dist/css/bpmn.css
+++ b/dist/css/bpmn.css
@@ -1,3 +1,4 @@
+@charset "utf-8";
 @font-face {
   font-family: 'bpmn';
   src: url('../font/bpmn.eot?21877404');


### PR DESCRIPTION
### Descrive the bug
I used `bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css` for my palette panel bpmn, but sometimes i got this, it seems it may be reproduce only in google chrome browser, i tried to experement with my css file connection but it still doesn’t work

### Assets
![image](https://github.com/bpmn-io/bpmn-font/assets/62372648/2b886133-8499-465f-8102-fc5516683f54)
![image](https://github.com/bpmn-io/bpmn-font/assets/62372648/06bd44b0-12b7-4560-a8bf-de7e5aeba4dd)

### Solution
I added explicit encoding into root css of bpmn font style and everything work well 

```resources: https://stackoverflow.com/questions/57910667/chrome-not-displaying-webfont-falling-back-to-times-new-roman-when-font-face-de
```


link the issue: https://forum.bpmn.io/t/broken-icon-coding/9564
